### PR TITLE
enabling checkpoints in model serving flink jobs

### DIFF
--- a/doc/als-model-serving.txt
+++ b/doc/als-model-serving.txt
@@ -1,0 +1,161 @@
+Script to load the ALS model to Kafka Topic
+-------------------------------------------
+
+bin/zookeeper-server-start.sh config/zookeeper.properties &
+
+0. (If not exists) create a multinode kafka cluster
+
+cp config/server.properties config/server-1.properties
+cp config/server.properties config/server-2.properties
+
+
+config/server.properties:
+    broker.id=0
+    listeners=PLAINTEXT://:9092
+    log.dir=/tmp/kafka-logs
+
+config/server-1.properties:
+    broker.id=1
+    listeners=PLAINTEXT://:9093
+    log.dir=/tmp/kafka-logs-1
+
+config/server-2.properties:
+    broker.id=2
+    listeners=PLAINTEXT://:9094
+    log.dir=/tmp/kafka-logs-2
+
+
+bin/kafka-server-start.sh config/server.properties &    
+bin/kafka-server-start.sh config/server-1.properties &
+bin/kafka-server-start.sh config/server-2.properties &
+
+1. (If not exists) create the kafka topic
+=========================================
+
+create topic ‘als’
+bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 3 --topic als
+
+check with a console consumer:
+bin/kafka-console-consumer.sh --bootstrap-server localhost:9092,localhost:9093,localhost:9094 --topic als --from-beginning
+
+
+2. Run Flink ALS
+================
+
+bin/flink run -c de.tub.it4bi.ALSImpl /Users/zis/git/flink-ms/flink-als/target/flink-als-1.0-SNAPSHOT.jar \
+--input /Users/zis/Documents/IT4BI/semester-IV/data/ml-20m/ratings.csv \
+--itemFactors /tmp/ml-20m/itemFactors  \
+--userFactors /tmp/ml-20m/userFactors
+
+
+3. Start the Flink Streaming application
+========================================
+
+bin/flink run -c de.tub.it4bi.modelserving.qs.ALSKafkaConsumer /Users/zis/git/flink-ms/als-ms/target/als-ms-1.0-SNAPSHOT.jar \
+--topic als \
+--stateBackend rocksdb \
+--checkpointDataUri 'file:///Users/zis/flink-state/checkpoint/als' \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094 \
+--zookeeper.connect localhost:2181 \
+--group.id als-consumer-group 
+
+
+4. Load data to Kafka topic
+===========================
+
+bin/flink run -c de.tub.it4bi.modelserving.qs.ALSKafkaProducer /Users/zis/git/flink-ms/als-ms/target/als-ms-1.0-SNAPSHOT.jar \
+--input /tmp/factors \
+--topic als \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094
+
+ml-20m
+------
+bin/flink run -c de.tub.it4bi.modelserving.qs.ALSKafkaProducer /Users/zis/git/flink-ms/als-ms/target/als-ms-1.0-SNAPSHOT.jar \
+--input /tmp/ml-20m \
+--topic als \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094
+
+
+5. Cancel the job with a save point
+===================================
+
+bin/flink cancel -s [:targetDirectory] :jobId
+
+bin/flink cancel -s /Users/zis/flink-state/savepoints/als :jobId
+
+6. Restart from savepoint
+=========================
+
+bin/flink run -s :savepointPath [:runArgs]
+
+bin/flink run -s /Users/zis/flink-state/savepoints/als/savepoint-id \
+-c de.tub.it4bi.modelserving.qs.ALSKafkaConsumer /Users/zis/git/flink-ms/als-ms/target/als-ms-1.0-SNAPSHOT.jar \
+--topic als \
+--stateBackend rocksdb \
+--checkpointDataUri 'file:///Users/zis/flink-state/checkpoint/als' \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094 \
+--zookeeper.connect localhost:2181 \
+--group.id als-consumer-group
+
+
+7. Query client
+===============
+
+java -cp flink-queryable-client/target/flink-queryable-client-1.0-SNAPSHOT-allinone.jar de.tub.it4bi.modelserving.qs.ALSPredictRandom \
+--jobId  val \
+--jobManagerHost val \
+--jobManagerPort val \
+--numQueries val \
+--upperItemId val \
+--upperUserId val \
+--lowerItemId val \
+--lowerUserId val \
+--queryTimeout val \
+--outputFile val
+
+eg:
+
+java -cp flink-queryable-client/target/flink-queryable-client-1.0-SNAPSHOT-allinone.jar de.tub.it4bi.modelserving.qs.ALSPredictRandom \
+--jobId d49791b4a6c77e36380252c853334fc3 \
+--numQueries 10000  \
+--upperItemId 131262  \
+--upperUserId 138000 \
+--outputFile /tmp/results.csv
+
+
+
+
+8. To see the status
+====================
+
+kafka topic:
+bin/kafka-topics.sh --describe --zookeeper localhost:2181 --topic als
+bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list localhost:9092,localhost:9093,localhost:9094 -topic als
+
+consumer group:
+bin/kafka-consumer-groups.sh --describe --zookeeper localhost:2181  --describe  --group als-consumer-group
+bin/kafka-consumer-groups.sh --list --zookeeper localhost:2181
+
+
+9. To delete 
+============
+
+topic:
+bin/kafka-run-class.sh kafka.admin.TopicCommand --zookeeper localhost:2181 --delete --topic als 
+bin/kafka-topics.sh --delete  --zookeeper localhost:2181  --topic als
+
+consumer group:
+bin/kafka-consumer-groups.sh --zookeeper localhost:2181 --delete --group als-consumer-group
+
+to delete savepoints:
+bin/flink savepoint -d :savepointPath
+bin/flink savepoint -d /Users/zis/flink-state/savepoints/als
+
+
+10. To shutdown kafka cluster
+============================
+
+bin/kafka-server-stop.sh
+bin/zookeeper-server-stop.sh
+
+# end of document

--- a/doc/svm-model-serving.txt
+++ b/doc/svm-model-serving.txt
@@ -1,0 +1,145 @@
+Script to load the SVM model to Kafka Topic
+-------------------------------------------
+
+bin/zookeeper-server-start.sh config/zookeeper.properties &
+
+0. (If not exists) create a multinode kafka cluster
+
+cp config/server.properties config/server-1.properties
+cp config/server.properties config/server-2.properties
+
+
+config/server.properties:
+    broker.id=0
+    listeners=PLAINTEXT://:9092
+    log.dir=/tmp/kafka-logs
+
+config/server-1.properties:
+    broker.id=1
+    listeners=PLAINTEXT://:9093
+    log.dir=/tmp/kafka-logs-1
+
+config/server-2.properties:
+    broker.id=2
+    listeners=PLAINTEXT://:9094
+    log.dir=/tmp/kafka-logs-2
+
+
+bin/kafka-server-start.sh config/server.properties &    
+bin/kafka-server-start.sh config/server-1.properties &
+bin/kafka-server-start.sh config/server-2.properties &
+
+1. (If not exists) create the kafka topic
+=========================================
+
+create topic ‘svm’
+bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 3 --topic svm
+
+check with a console consumer:
+bin/kafka-console-consumer.sh --bootstrap-server localhost:9092,localhost:9093,localhost:9094 --topic svm --from-beginning
+
+2. Run Flink SVM
+================
+
+bin/flink run -c de.tub.it4bi.SVMImpl /Users/zis/git/flink-ms/flink-svm/target/flink-svm-1.0-SNAPSHOT.jar \
+--training /Users/zis/Documents/IT4BI/semester-IV/data/url_svmlight_small \
+--output /tmp/url_svmlight_out
+
+3. Start the Flink Streaming application
+========================================
+
+bin/flink run -c de.tub.it4bi.modelserving.qs.SVMKafkaConsumer /Users/zis/git/flink-ms/svm-ms/target/svm-ms-1.0-SNAPSHOT.jar \
+--topic svm \
+--checkpointDataUri 'file:///tmp/checkpoint' \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094 \
+--zookeeper.connect localhost:2181 \
+--group.id svm-consumer-group \
+--stateBackend rocksdb
+
+4. Load the data
+================
+
+bin/flink run -c de.tub.it4bi.modelserving.qs.SVMKafkaProducer /Users/zis/git/flink-ms/svm-ms/target/svm-ms-1.0-SNAPSHOT.jar \
+--input /tmp/url_svmlight_out \
+--topic svm \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094
+
+5. Cancel the job with a save point
+===================================
+
+bin/flink cancel -s [:targetDirectory] :jobId
+
+bin/flink cancel -s /Users/zis/flink-state/savepoints/svm :jobId
+
+6. Restart from savepoint
+=========================
+
+bin/flink run -s :savepointPath [:runArgs]
+
+bin/flink run -s /Users/zis/flink-state/savepoints/svm/savepoint-id \
+-c de.tub.it4bi.modelserving.qs.SVMKafkaConsumer /Users/zis/git/flink-ms/svm-ms/target/svm-ms-1.0-SNAPSHOT.jar \
+--topic svm \
+--checkpointDataUri 'file:///tmp/checkpoint' \
+--bootstrap.servers localhost:9092,localhost:9093,localhost:9094 \
+--zookeeper.connect localhost:2181 \
+--group.id svm-consumer-group \
+--stateBackend rocksdb
+
+7. Query client
+===============
+
+java -cp flink-queryable-client/target/flink-queryable-client-1.0-SNAPSHOT-allinone.jar de.tub.it4bi.modelserving.qs.SVMPredictRandom \
+--jobId  val \
+--jobManagerHost val \
+--jobManagerPort val \
+--outputDecisionFunction val \
+--thresholdValue val \
+--numQueries val \
+--maxNoOfFeatures val \
+--minPercentageOfFeatures val \
+--queryTimeout val \
+--outputFile val
+
+eg:
+
+java -cp flink-queryable-client/target/flink-queryable-client-1.0-SNAPSHOT-allinone.jar de.tub.it4bi.modelserving.qs.SVMPredictRandom \
+--jobId d49791b4a6c77e36380252c853334fc3 \
+--numQueries 10000  \
+--maxNoOfFeatures 323195  \
+--outputFile /tmp/results.csv
+
+8. To see the status
+====================
+
+kafka topic:
+bin/kafka-topics.sh --describe --zookeeper localhost:2181 --topic als
+bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list localhost:9092,localhost:9093,localhost:9094 -topic als
+
+consumer group:
+bin/kafka-consumer-groups.sh --describe --zookeeper localhost:2181  --describe  --group als-consumer-group
+bin/kafka-consumer-groups.sh --list --zookeeper localhost:2181
+
+
+9. To delete 
+============
+
+topic:
+bin/kafka-run-class.sh kafka.admin.TopicCommand --zookeeper localhost:2181 --delete --topic als 
+bin/kafka-topics.sh --delete  --zookeeper localhost:2181  --topic als
+
+consumer group:
+bin/kafka-consumer-groups.sh --zookeeper localhost:2181 --delete --group als-consumer-group
+
+to delete savepoints:
+bin/flink savepoint -d :savepointPath
+bin/flink savepoint -d /Users/zis/flink-state/savepoints/svm
+
+
+10. To shutdown kafka cluster
+============================
+
+bin/kafka-server-stop.sh
+bin/zookeeper-server-stop.sh
+
+# end of document
+

--- a/svm-ms/src/main/java/de/tub/it4bi/modelserving/qs/SVMKafkaConsumer.java
+++ b/svm-ms/src/main/java/de/tub/it4bi/modelserving/qs/SVMKafkaConsumer.java
@@ -1,7 +1,9 @@
 package de.tub.it4bi.modelserving.qs;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -15,6 +17,7 @@ import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer010;
 import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by zis on 06/05/17.
@@ -25,18 +28,25 @@ public class SVMKafkaConsumer {
         // parse input arguments
         final ParameterTool parameterTool = ParameterTool.fromArgs(args);
 
-        if (parameterTool.getNumberOfParameters() < 4) {
+        if (parameterTool.getNumberOfParameters() < 6) {
             System.out.println("Missing parameters!\nUsage: Kafka --topic <topic> " +
                     "--bootstrap.servers <kafka brokers> --zookeeper.connect <zk quorum> --group.id <some id>" +
                     "--checkpointDataUri <hdfs/local url> --stateBackend <rocksdb/memory/fs> ");
             return;
         }
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-
         env.getConfig().disableSysoutLogging();
-        // env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(4, 10000));
-        // env.enableCheckpointing(5000); // create a checkpoint every 5 seconds
-        env.getConfig().setGlobalJobParameters(parameterTool); // make parameters available in the web interface
+        env.getConfig().setGlobalJobParameters(parameterTool);
+
+        // default checkpoint interval is set to 1 minute
+        env.enableCheckpointing(parameterTool.getInt("checkPointInterval", 60000));
+        // allow only one checkpoint to be in progress at the same time
+        env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
+        // fixed delay restart
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
+                3, // number of restart attempts
+                Time.of(10, TimeUnit.SECONDS) // delay
+        ));
 
         // set state backend
         try {


### PR DESCRIPTION
fixes #8 
checkpointing is enabled in the model serving jobs. Now we can cancel a job with save points and 
restart the job later using this save point. So data is read from kafka topic only in the beginning and to access model later, we simply need to restart the job using the save point (see the documentation)